### PR TITLE
Rewrite all Skeleton logic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "spine_tiny"
-version = "0.0.1"
-authors = [ "pierre.krieger1708@gmail.com" ]
+version = "0.1.0"
+authors = [ "Pierre Krieger <pierre.krieger1708@gmail.com>",
+            "Johann Tuffe <tafia973@gmail.com>"]
 description = "Simple implementation of the Spine runtime"
 license = "Apache-2.0"
 repository = "https://github.com/tomaka/spine-rs"
@@ -11,11 +12,7 @@ name = "spine"
 path = "src/lib.rs"
 
 [dependencies]
-cgmath = "0.3"
-libc = "0.1"
-
-[dependencies.color]
-git = "https://github.com/bjz/color-rs.git"
+rustc-serialize = "0.3"
 
 [dependencies.from_json]
 git = "https://github.com/tomaka/from_json"

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -1,4 +1,4 @@
-#![feature(test)] 
+#![feature(test)]
 
 extern crate spine;
 extern crate test;
@@ -7,20 +7,39 @@ extern crate clock_ticks;
 use std::io::BufReader;
 
 #[bench]
-fn loading(bencher: &mut test::Bencher) {
+fn loading_json(bencher: &mut test::Bencher) {
     let src: &[u8] = include_bytes!("../tests/example.json");
-
     bencher.iter(|| {
-        spine::SpineDocument::new(BufReader::new(src))
+        spine::skeleton::Skeleton::from_reader(BufReader::new(src))
     });
 }
 
 #[bench]
 fn animation(bencher: &mut test::Bencher) {
+
     let src: &[u8] = include_bytes!("../tests/example.json");
-    let doc = spine::SpineDocument::new(BufReader::new(src)).unwrap();
+    let doc = spine::skeleton::Skeleton::from_reader(BufReader::new(src)).unwrap();
 
     bencher.iter(|| {
-        doc.calculate("default", Some("walk"), (clock_ticks::precise_time_ns() / 1000000) as f32 / 1000.0)
+        if let Ok(anim) = doc.get_animated_skin("default", Some("walk")) {
+            anim.interpolate(0.01);
+        }
+    })
+}
+
+#[bench]
+fn animation_all(bencher: &mut test::Bencher) {
+
+    let src: &[u8] = include_bytes!("../tests/example.json");
+    let doc = spine::skeleton::Skeleton::from_reader(BufReader::new(src)).unwrap();
+
+    bencher.iter(|| {
+        if let Ok(anim) = doc.get_animated_skin("default", Some("walk")) {
+            for sprites in anim.run(0.01).take(100) {
+                for a in sprites {
+                    let _ = a;
+                }
+            }
+        }
     })
 }

--- a/src/atlas.rs
+++ b/src/atlas.rs
@@ -1,0 +1,190 @@
+//! Module to import .atlas files
+
+use std::io::{BufReader, Lines};
+use std::io::prelude::*;
+use std::fmt;
+use std::error::Error;
+use std::str::ParseBoolError;
+
+/// atlas texture
+pub struct Texture {
+    /// name
+    pub name: String,
+    /// rotate
+    pub rotate: bool,
+    /// position
+    pub xy: (u16, u16),
+    /// size
+    pub size: (u16, u16),
+    /// orig
+    pub orig: (u16, u16),
+    /// offset
+    pub offset: (u16, u16),
+    /// index
+    pub index: i16,
+}
+
+/// Iterator to parse attachments from a common image
+pub struct Atlas<R: Read> {
+    /// file
+    pub file: String,
+    /// format
+    pub format: String,
+    /// filter
+    pub filter: String,
+    /// repeat
+    pub repeat: String,
+    lines: Lines<BufReader<R>>
+}
+
+impl<R: Read> Atlas<R> {
+
+    /// consumes a reader on .atlas file and create a Atlas iterator
+    pub fn from_reader(reader: R) -> Result<Atlas<R>, AtlasError> {
+        let mut lines = BufReader::new(reader).lines();
+        while let Some(line) = lines.next() {
+            let line = try!(line);
+            if line.trim().len() > 0 {
+
+                let file = line;
+                let val = try!(next_line(&mut lines));
+                let format = val["format:".len()..].trim().to_owned();
+                let val = try!(next_line(&mut lines));
+                let filter = val["filter:".len()..].trim().to_owned();
+                let val = try!(next_line(&mut lines));
+                let repeat = val["repeat:".len()..].trim().to_owned();
+
+                return Ok(Atlas {
+                    file: file,
+                    format: format,
+                    filter: filter,
+                    repeat: repeat,
+                    lines: lines
+                });
+            }
+        }
+        Err(AtlasError::Unexpected("cannot parse headers"))
+    }
+
+    fn read_texture(&mut self, name: &str) -> Result<Texture, AtlasError> {
+        let rotate = {
+            let line = try!(next_line(&mut self.lines));
+            try!(line.trim_left()["rotate:".len()..].trim().parse())
+        };
+        let mut tuples = Vec::with_capacity(4);
+        for pattern in ["xy:", "size:", "orig:", "offset:"].into_iter() {
+            let val = try!(self.parse_tuple(pattern.len()));
+            tuples.push(val);
+        }
+        let index = {
+            let line = try!(next_line(&mut self.lines));
+            try!(line.trim_left()["index:".len()..].trim().parse())
+        };
+        Ok(Texture {
+            name: name.to_owned(),
+            rotate: rotate,
+            xy: tuples[0],
+            size: tuples[1],
+            orig: tuples[2],
+            offset: tuples[3],
+            index: index,
+        })
+    }
+
+    fn parse_tuple(&mut self, offset: usize) -> Result<(u16, u16), AtlasError> {
+        let line = try!(next_line(&mut self.lines));
+        let mut tuple = Vec::with_capacity(2);
+        for s in line.trim_left()[offset..].split(',').take(2) {
+            let a = try!(s.trim().parse());
+            tuple.push(a);
+        }
+        if tuple.len() != 2 {
+            Err(AtlasError::Unexpected("tuple"))
+        } else {
+            Ok((tuple[0], tuple[1]))
+        }
+    }
+}
+
+fn next_line<R: Read>(lines: &mut Lines<BufReader<R>>) -> Result<String, AtlasError> {
+    match lines.next() {
+        Some(Ok(line)) => Ok(line),
+        Some(Err(e)) => Err(AtlasError::from(e)),
+        None => Err(AtlasError::Unexpected("EOF"))
+    }
+}
+
+impl<R: Read> Iterator for Atlas<R> {
+    type Item = Result<Texture, AtlasError>;
+    fn next(&mut self) -> Option<Result<Texture, AtlasError>> {
+        loop {
+            return match self.lines.next() {
+                Some(Ok(name)) => {
+                    let name = name.trim();
+                    if name.len() == 0 { continue; }
+                    Some(self.read_texture(name.trim()))
+                },
+                Some(Err(e)) => Some(Err(AtlasError::from(e))),
+                None         => None
+            }
+        }
+    }
+}
+
+/// Atlas errors
+pub enum AtlasError {
+    /// io error
+    IoError(::std::io::Error),
+    /// unexpected error, with descriptiom
+    Unexpected(&'static str),
+    /// error when parsing u16 or i16
+    ParseIntError(::std::num::ParseIntError),
+    /// error when parsing boolean
+    ParseBoolError(::std::str::ParseBoolError)
+}
+
+impl fmt::Display for AtlasError {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self, formatter)
+    }
+}
+
+impl Error for AtlasError {
+    fn description(&self) -> &str {
+        match *self {
+            AtlasError::ParseIntError(_) => "error parsing integer",
+            AtlasError::ParseBoolError(_) => "error parsing boolean",
+            AtlasError::Unexpected(_) => "unexpected error",
+            AtlasError::IoError(_) => "error reading atlas file",
+        }
+    }
+}
+
+impl fmt::Debug for AtlasError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            AtlasError::ParseIntError(ref e) => write!(f, "Cannot parse integer: {:?}", e),
+            AtlasError::ParseBoolError(ref e) => write!(f, "Cannot parse boolean: {:?}", e),
+            AtlasError::Unexpected(s) => write!(f, "Unexpected error: {}", s),
+            AtlasError::IoError(ref e) => write!(f, "Error reading atlas file: {:?}", e),
+        }
+    }
+}
+
+impl From<::std::io::Error> for AtlasError {
+    fn from(error: ::std::io::Error) -> AtlasError {
+        AtlasError::IoError(error)
+    }
+}
+
+impl From<::std::num::ParseIntError> for AtlasError {
+    fn from(error: ::std::num::ParseIntError) -> AtlasError {
+        AtlasError::ParseIntError(error)
+    }
+}
+
+impl From<ParseBoolError> for AtlasError {
+    fn from(error: ParseBoolError) -> AtlasError {
+        AtlasError::ParseBoolError(error)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,682 +1,87 @@
-/*!
-# spine
+//! # spine
+//!
+//! Parses a Spine document and calculates what needs to be drawn.
+//!
+//! ## Step 1: loading the document
+//!
+//! Call `skeleton::Skeleton::from_reader` to parse the content of a document.
+//!
+//! This function returns an `Err` if the document is not valid JSON or if something is not
+//!  recognized in it.
+//!
+//! ```no_run
+//! # use std::fs::File;
+//! # use std::path::Path;
+//! let skeleton = spine::skeleton::Skeleton::from_reader(File::open(&Path::new("skeleton.json")).unwrap())
+//!     .unwrap();
+//! ```
+//!
+//! ## Step 2: preparing for drawing
+//!
+//! You can retreive the list of animations and skins provided a document:
+//!
+//! ```no_run
+//! # let skeleton: spine::skeleton::Skeleton = unsafe { std::mem::uninitialized() };
+//! let skins = skeleton.get_skins_names();
+//! let animations = skeleton.get_animations_names();
+//! ```
+//!
+//! You can also get a list of the names of all the sprites that can possibly be drawn by this
+//!  Spine animation.
+//!
+//! ```no_run
+//! # let skeleton: spine::skeleton::Skeleton = unsafe { std::mem::uninitialized() };
+//! let sprites = skeleton.get_attachments_names();
+//! ```
+//!
+//! Note that the names do not necessarly match file names. They are the same names that you have in
+//!  the Spine editor. It is your job to turn these resource names into file names if necessary.
+//!
+//! ## Step 3: animating
+//!
+//! To run an animation, you first need to call `skeleton.get_animated_skin` to get a `SkinAnimation`.
+//! You then have 2 methods to get the sprites you need to draw:
+//! - directly call `animation.interpolate` for a given time
+//! - use a built-in `AnimationIter` iterator by calling `animation.run()` to run the animation
+//! with a constant period
+//!
+//! Both methods returns a `Sprites` iterator over the `Sprite`s do be drawn.
+//!
+//! ```no_run
+//! # let skeleton: spine::skeleton::Skeleton = unsafe { std::mem::uninitialized() };
+//! let animation = skeleton.get_animated_skin("default", Some("walk")).unwrap();
+//! let sprites = animation.interpolate(0.3).unwrap();
+//! // equivalent to
+//! let sprites = animation
+//!               .run(0.1)  // iterator that interpolates sprites every 0.1s
+//!               .nth(3);   // get the 3rd item generated when time = 0.3
+//! ```
+//!
+//! The result contains an iterator over the sprites that need to be drawn with the `skeleton::SRT`
+//! (scale, rotate, translate)). The srt supposes that each sprite would cover the whole viewport
+//! (ie. drawn from `(-1, -1)` to `(1, 1)`).  You can convert it to a premultiplied matrix using
+//! `srt.to_matrix3()` or `srt.to_matrix4` ; if you want to apply your own matrix `C` over
+//!  the one returned `M`, you need to call `C * M`.
+//!
+//! ```no_run
+//! # use std::collections::HashMap;
+//! # let skeleton: spine::skeleton::Skeleton = unsafe { std::mem::uninitialized() };
+//! # let textures_list: HashMap<&str, i32> = unsafe { std::mem::uninitialized() };
+//! # let animation = skeleton.get_animated_skin("default", Some("walk")).unwrap();
+//! # fn draw<A,B,C>(_: A, _: B, _: C) {}
+//! for sprite in animation.interpolate(0.3).unwrap() {
+//!     let texture = textures_list.get(&&*sprite.attachment).unwrap();
+//!     draw(texture, &sprite.srt, &sprite.color);
+//! }
+//! ```
+//!
 
-Parses a Spine document and calculates what needs to be drawn.
-
-## Step 1: loading the document
-
-Call `SpineDocument::new` to parse the content of a document.
-
-This function returns an `Err` if the document is not valid JSON or if something is not
- recognized in it.
-
-```no_run
-# use std::fs::File;
-# use std::path::Path;
-let document = spine::SpineDocument::new(File::open(&Path::new("skeleton.json")).unwrap())
-    .unwrap();
-```
-
-## Step 2: preparing for drawing
-
-You can retreive the list of animations and skins provided a document:
-
-```no_run
-# let document: spine::SpineDocument = unsafe { std::mem::uninitialized() };
-let skins = document.get_skins_list();
-
-let animations = document.get_animations_list();
-let first_animation_duration = document.get_animation_duration(animations[0]).unwrap();
-```
-
-You can also get a list of the names of all the sprites that can possibly be drawn by this
- Spine animation.
-
-```no_run
-# let document: spine::SpineDocument = unsafe { std::mem::uninitialized() };
-let sprites = document.get_possible_sprites();
-```
-
-Note that the names do not necessarly match file names. They are the same names that you have in
- the Spine editor. It is your job to turn these resource names into file names if necessary.
-
-## Step 3: animating
-
-At each frame, call `document.calculate()` in order to get the list of things that need to be
- drawn for the current animation.
-
-This function takes the skin name, the animation name (or `None` for the default pose) and the
- time in the current animation's loop.
-
-```no_run
-# let document: spine::SpineDocument = unsafe { std::mem::uninitialized() };
-let results = document.calculate("default", Some("walk"), 0.176).unwrap();
-```
-
-The results contain the list of sprites that need to be drawn, with their matrix. The matrix
- supposes that each sprite would cover the whole viewport (ie. drawn from `(-1, -1)` to
- `(1, 1)`). The matrix is pre-multiplying ; if you want to apply your own matrix `C` over
- the one returned, you need to call `C * M`.
-
-```no_run
-# use std::collections::HashMap;
-# let results: spine::Calculation = unsafe { std::mem::uninitialized() };
-# let textures_list: HashMap<&str, i32> = unsafe { std::mem::uninitialized() };
-# fn draw<A,B,C>(_: A, _: B, _: C) {}
-for (sprite_name, matrix, color) in results.sprites.into_iter() {
-    let texture = textures_list.get(&sprite_name).unwrap();
-    draw(texture, matrix, color);
-}
-```
-
-*/
 #![deny(missing_docs)]
 
-extern crate color;
-extern crate cgmath;
 #[macro_use]
 extern crate from_json;
-
-use color::{Rgb, Rgba};
-use cgmath::Matrix4;
-
-use std::io::Read;
-
-mod format;
-
-/// Spine document loaded in memory.
-pub struct SpineDocument {
-    source: format::Document,
-}
-
-impl SpineDocument {
-    /// Loads a document from a reader.
-    pub fn new<R: Read>(mut reader: R) -> Result<SpineDocument, String> {
-        let document = try!(from_json::Json::from_reader(&mut reader).map_err(|e| format!("{:?}", e)));
-        let document: format::Document = try!(from_json::FromJson::from_json(&document)
-            .map_err(|e| format!("{:?}", e)));
-
-        Ok(SpineDocument {
-            source: document
-        })
-    }
-
-    /// Returns the list of all animations in this document.
-    pub fn get_animations_list(&self) -> Vec<&str> {
-        if let Some(ref list) = self.source.animations {
-            list.keys().map(|e| &e[..]).collect()
-        } else {
-            Vec::new()
-        }
-    }
-
-    /// Returns the list of all skins in this document.
-    pub fn get_skins_list(&self) -> Vec<&str> {
-        if let Some(ref list) = self.source.skins {
-            list.keys().map(|e| &e[..]).collect()
-        } else {
-            Vec::new()
-        }
-    }
-
-    /// Returns true if an animation is in the document.
-    pub fn has_animation(&self, name: &str) -> bool {
-        if let Some(ref list) = self.source.animations {
-            list.get(&name.to_string()).is_some()
-        } else {
-            false
-        }
-    }
-
-    /// Returns true if a skin is in the document.
-    pub fn has_skin(&self, name: &str) -> bool {
-        if let Some(ref list) = self.source.skins {
-            list.get(&name.to_string()).is_some()
-        } else {
-            false
-        }
-    }
-
-    /// Returns the duration of an animation.
-    ///
-    /// Returns `None` if the animation doesn't exist.
-    /// 
-    /// TODO: check events and draworder?
-    pub fn get_animation_duration(&self, animation: &str) -> Option<f32> {
-        // getting a reference to the `format::Animation`
-        let animation: &format::Animation = 
-            if let Some(anim) = self.source.animations.as_ref() {
-                match anim.get(animation) {
-                    Some(a) => a,
-                    None => return None
-                }
-            } else {
-                return None;
-            };
-
-        // this contains the final result
-        let mut result = 0.0f64;
-
-        // checking the bones
-        if let Some(ref bones) = animation.bones {
-            for timelines in bones.values() {
-                if let Some(ref translate) = timelines.translate.as_ref() {
-                    for elem in translate.iter() {
-                        if elem.time > result { result = elem.time }
-                    }
-                }
-                if let Some(ref rotate) = timelines.rotate.as_ref() {
-                    for elem in rotate.iter() {
-                        if elem.time > result { result = elem.time }
-                    }
-                }
-                if let Some(ref scale) = timelines.scale.as_ref() {
-                    for elem in scale.iter() {
-                        if elem.time > result { result = elem.time }
-                    }
-                }
-            }
-        }
-
-        // checking the slots
-        if let Some(ref slots) = animation.slots {
-            for timelines in slots.values() {
-                if let Some(ref attachment) = timelines.attachment.as_ref() {
-                    for elem in attachment.iter() {
-                        if elem.time > result { result = elem.time }
-                    }
-                }
-                if let Some(ref color) = timelines.color.as_ref() {
-                    for elem in color.iter() {
-                        if elem.time > result { result = elem.time }
-                    }
-                }
-            }
-        }
-
-        // returning
-        Some(result as f32)
-    }
-
-    /// Returns a list of all possible sprites when drawing.
-    ///
-    /// The purpose of this function is to allow you to preload what you need.
-    pub fn get_possible_sprites(&self) -> Vec<&str> {
-        if let Some(ref list) = self.source.skins {
-            let mut result = list.iter().flat_map(|(_, skin)| skin.iter())
-                                 .flat_map(|(_, slot)| slot.iter())
-                                 .map(|(name, vals)| {
-                                     if let Some(ref name) = vals.name {
-                                         &name[..]
-                                     } else {
-                                         &name[..]
-                                     }
-                                 })
-                                 .collect::<Vec<_>>();
-
-            result.sort();
-            result.dedup();
-            result
-
-        } else {
-            Vec::new()
-        }
-    }
-
-    /// Calculates the list of sprites that must be displayed and their matrix.
-    ///
-    /// If `elapsed` is longer than the duration of the animation, it will be modulo'd.
-    // TODO: implement draw order timeline
-    // TODO: implement events
-    // TODO: implement other attachment types
-    pub fn calculate(&self, skin: &str, animation: Option<&str>, mut elapsed: f32) 
-        -> Result<Calculation, CalculationError>
-    {
-        // adapting elapsed
-        if let Some(animation) = animation {
-            if let Some(duration) = self.get_animation_duration(animation) {
-                elapsed = elapsed % duration;
-            }
-        }
-        let elapsed = elapsed;
-
-        // getting a reference to the `format::Skin`
-        let skin = try!(self.source.skins.as_ref().and_then(|l| l.get(skin))
-            .ok_or(CalculationError::SkinNotFound));
-
-        // getting a reference to "default" skin
-        let default_skin = try!(self.source.skins.as_ref().and_then(|l| l.get("default"))
-            .ok_or(CalculationError::SkinNotFound));
-
-        // getting a reference to the `format::Animation`
-        let animation: Option<&format::Animation> = match animation {
-            Some(animation) => Some(try!(self.source.animations.as_ref()
-                .and_then(|l| l.get(animation)).ok_or(CalculationError::AnimationNotFound))),
-            None => None
-        };
-
-        // calculating the default pose of all bones
-        let mut bones: Vec<(&format::Bone, BoneData)> = self.source.bones.as_ref().map(|bones| {
-            bones.iter().map(|bone| (bone, get_bone_default_local_setup(bone))).collect()
-        }).unwrap_or_else(|| Vec::new());
-
-        // if we are animating, adding to the default pose the calculations from the animation
-        if let Some(animation) = animation {
-            if let Some(anim_bones) = animation.bones.as_ref() {
-                for (bone_name, timelines) in anim_bones.iter() {
-                    // calculating the variation from the animation
-                    let anim_data = try!(timelines_to_bonedata(timelines, elapsed));
-
-                    // adding this to the `bones` vec above
-                    match bones.iter_mut().find(|&&mut (b, _)| b.name == *bone_name) {
-                        Some(&mut (_, ref mut data)) => { *data = data.clone() + anim_data; },
-                        None => ()
-                    };
-                }
-            }
-        };
-
-        // now we have our list of bones with their relative positions
-        // adding the position of the parent to each bone
-        let bones: Vec<(&str, Matrix4<f32>)> = bones.iter().map(|&(ref bone, ref relative_data)| {
-            let mut current_matrix = relative_data.to_matrix();
-            let mut current_parent = bone.parent.as_ref();
-
-            loop {
-                if let Some(parent_name) = current_parent {
-                    assert!(parent_name != &bone.name);     // prevent infinite loop
-
-                    match bones.iter().find(|&&(b, _)| b.name == *parent_name) {
-                        Some(ref p) => {
-                            current_parent = p.0.parent.as_ref();
-                            current_matrix = p.1.to_matrix() * current_matrix;
-                        },
-                        None => {
-                            current_parent = None;  // TODO: return BoneNotFound(parent_name);
-                        }
-                    }
-
-                } else {
-                    break
-                }
-            }
-
-            (&bone.name[..], current_matrix.clone())
-
-        }).collect();
-
-        // now taking each slot in the document and matching its bone
-        // `slots` contains the slot name, bone data, color, and attachment
-        let mut slots: Vec<(&str, Matrix4<f32>, Option<&str>, Option<&str>)> =
-            if let Some(slots) = self.source.slots.as_ref() {
-                let mut result = Vec::new();
-
-                for slot in slots.iter() {
-                    let bone = try!(bones.iter().find(|&&(name, _)| name == slot.bone)
-                        .ok_or(CalculationError::BoneNotFound(&slot.bone)));
-                    result.push((&slot.name[..], bone.1, slot.color.as_ref()
-                        .map(|s| &s[..]), slot.attachment.as_ref().map(|s| &s[..])))
-                }
-
-                result
-
-            } else {
-                Vec::new()
-            };
-
-        // if we are animating, replacing the values by the ones overridden by the animation
-        if let Some(animation) = animation {
-            if let Some(anim_slots) = animation.slots.as_ref() {
-                for (slot_name, timelines) in anim_slots.iter() {
-                    // calculating the variation from the animation
-                    let (anim_color, anim_attach) =
-                        try!(timelines_to_slotdata(timelines, elapsed));
-
-                    // adding this to the `slots` vec above
-                    match slots.iter_mut().find(|&&mut (s, _, _, _)| s == slot_name) {
-                        Some(&mut (_, _, ref mut color, ref mut attachment)) => {
-                            if let Some(c) = anim_color { *color = Some(c) };
-                            if let Some(a) = anim_attach { *attachment = Some(a) };
-                        },
-                        None => ()
-                    };
-                }
-            }
-        };
-
-        // now finding the attachment of each slot
-        let slots = {
-            let mut results = Vec::new();
-
-            for (slot_name, bone_data, _color, attachment) in slots.into_iter() {
-                if let Some(attachment) = attachment {
-                    let attachments = match skin.iter().chain(default_skin.iter())
-                                                .find(|&(slot, _)| slot == slot_name)
-                    {
-                        Some(a) => a,
-                        None => continue
-                    };
-
-                    let attachment = try!(attachments.1.iter()
-                        .find(|&(a, _)| a == attachment)
-                        .ok_or(CalculationError::AttachmentNotFound(attachment)));
-
-                    let attachment_transform = get_attachment_transformation(attachment.1);
-                    let bone_data = bone_data * attachment_transform;
-
-                    let attachment = if let Some(ref name) = attachment.1.name {
-                        &name[..]
-                    } else {
-                        &attachment.0[..]
-                    };
-
-                    results.push((
-                        attachment,
-                        bone_data,
-                        Rgba { a: 255, c: Rgb::new(255, 255, 255) }
-                    ));
-                }
-            }
-
-            results
-        };
-
-        // final result
-        Ok(Calculation {
-            sprites: slots
-        })
-    }
-}
-
-/// Result of an animation state calculation.
-#[derive(Debug)]
-pub struct Calculation<'a> {
-    /// The list of sprites that should be drawn.
-    ///
-    /// The elements are sorted from bottom to top, ie. each element can cover the previous one.
-    ///
-    /// The matrix assumes that the sprite is displayed from (-1, -1) to (1, 1), ie. would cover
-    ///  the whole screen.
-    pub sprites: Vec<(&'a str, Matrix4<f32>, Rgba<u8>)>,
-}
-
-/// Error that can happen while calculating an animation.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum CalculationError<'a> {
-    /// The requested skin was not found.
-    SkinNotFound,
-
-    /// The requested animation was not found.
-    AnimationNotFound,
-
-    /// The requested bone was not found in the list of bones.
-    ///
-    /// This probably means that the Spine document contains an error.
-    BoneNotFound(&'a str),
-
-    /// The requested slot was not found.
-    ///
-    /// This probably means that the Spine document contains an error.
-    SlotNotFound(&'a str),
-
-    /// The requested attachment was not found.
-    ///
-    /// This probably means that the Spine document contains an error.
-    AttachmentNotFound(&'a str),
-
-    /// The curve function was not recognized.
-    UnknownCurveFunction(String),
-}
-
-/// Informations about a bone's position.
-///
-/// Can be absolute or relative to its parent.
-#[derive(Debug, Clone)]
-struct BoneData {
-    position: (f32, f32),
-    rotation: f32,
-    scale: (f32, f32),
-}
-
-impl BoneData {
-    fn to_matrix(&self) -> Matrix4<f32> {
-        use cgmath::{Matrix2, Vector3};
-
-        let scale_matrix = Matrix4::new(self.scale.0, 0.0, 0.0, 0.0, 0.0, self.scale.1, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0);
-        let rotation_matrix = Matrix4::from(Matrix2::from_angle(cgmath::deg(self.rotation).into()));
-        let translation_matrix = Matrix4::from_translation(&Vector3::new(self.position.0, self.position.1, 0.0));
-
-        translation_matrix * rotation_matrix * scale_matrix
-    }
-}
-
-impl std::ops::Add<BoneData> for BoneData {
-    type Output = BoneData;
-
-    fn add(self, rhs: BoneData) -> BoneData {
-        BoneData {
-            position: (self.position.0 + rhs.position.0, self.position.1 + rhs.position.1),
-            rotation: self.rotation + rhs.rotation,
-            scale: (self.scale.0 * rhs.scale.0, self.scale.1 * rhs.scale.1),
-        }
-    }
-}
-
-/// Returns the setup pose of a bone relative to its parent.
-fn get_bone_default_local_setup(bone: &format::Bone) -> BoneData {
-    BoneData {
-        position: (bone.x.unwrap_or(0.0) as f32, bone.y.unwrap_or(0.0) as f32),
-        rotation: bone.rotation.unwrap_or(0.0) as f32,
-        scale: (bone.scaleX.unwrap_or(1.0) as f32, bone.scaleY.unwrap_or(1.0) as f32),
-    }
-}
-
-/// Returns the `Matrix` of an attachment.
-fn get_attachment_transformation(attachment: &format::Attachment) -> Matrix4<f32> {
-    BoneData {
-        position: (attachment.x.unwrap_or(0.0) as f32, attachment.y.unwrap_or(0.0) as f32),
-        rotation: attachment.rotation.unwrap_or(0.0) as f32,
-        scale: (
-            attachment.scaleX.unwrap_or(1.0) as f32 * attachment.width.unwrap_or(1.0) as f32 / 2.0,
-            attachment.scaleY.unwrap_or(1.0) as f32 * attachment.height.unwrap_or(1.0) as f32 / 2.0
-        ),
-    }.to_matrix()
-}
-
-/// Builds the `Matrix4` corresponding to a timeline.
-fn timelines_to_bonedata(timeline: &format::BoneTimeline, elapsed: f32) -> Result<BoneData, CalculationError> {
-    // calculating the current position
-    let position = if let Some(timeline) = timeline.translate.as_ref() {
-        // finding in which interval we are
-        match timeline.iter().zip(timeline.iter().skip(1))
-            .find(|&(before, after)| elapsed >= before.time as f32 && elapsed < after.time as f32)
-        {
-            Some((ref before, ref after)) => {
-                // calculating the value using the curve function
-                let position = (elapsed - (before.time as f32)) / ((after.time - before.time) as f32);
-
-                (
-                    try!(calculate_curve(&before.curve, before.x.unwrap_or(0.0) as f32,
-                        after.x.unwrap_or(0.0) as f32, position)),
-                    try!(calculate_curve(&before.curve, before.y.unwrap_or(0.0) as f32,
-                        after.y.unwrap_or(0.0) as f32, position))
-                )
-            },
-            None => {
-                // we didn't find an interval, assuming we are past the end
-                timeline.last().map(|t| (t.x.unwrap_or(0.0) as f32, t.y.unwrap_or(0.0) as f32))
-                    .unwrap_or((0.0, 0.0))
-            }
-        }
-
-    } else {
-        // we have no timeline
-        (0.0, 0.0)
-    };
-
-
-    // calculating the current rotation
-    let rotation = if let Some(timeline) = timeline.rotate.as_ref() {
-        // finding in which interval we are
-        match timeline.iter().zip(timeline.iter().skip(1))
-            .find(|&(before, after)| elapsed >= before.time as f32 && elapsed < after.time as f32)
-        {
-            Some((ref before, ref after)) => {
-                // calculating the value using the curve function
-                let position = (elapsed - (before.time as f32)) / ((after.time - before.time) as f32);
-
-                try!(calculate_curve(&before.curve, before.angle.unwrap_or(0.0) as f32,
-                    after.angle.unwrap_or(0.0) as f32, position))
-            },
-            None => {
-                // we didn't find an interval, assuming we are past the end
-                timeline.last().map(|t| t.angle.unwrap_or(0.0) as f32)
-                    .unwrap_or(0.0)
-            }
-        }
-
-    } else {
-        // we have no timeline
-        0.0
-    };
-
-
-    // calculating the current scale
-    let scale = if let Some(timeline) = timeline.scale.as_ref() {
-        // finding in which interval we are
-        match timeline.iter().zip(timeline.iter().skip(1))
-            .find(|&(before, after)| elapsed >= before.time as f32 && elapsed < after.time as f32)
-        {
-            Some((ref before, ref after)) => {
-                // calculating the value using the curve function
-                let position = (elapsed - (before.time as f32)) / ((after.time - before.time) as f32);
-
-                (
-                    try!(calculate_curve(&before.curve, before.x.unwrap_or(1.0) as f32,
-                        after.x.unwrap_or(1.0) as f32, position)),
-                    try!(calculate_curve(&before.curve, before.y.unwrap_or(1.0) as f32,
-                        after.y.unwrap_or(1.0) as f32, position))
-                )
-            },
-            None => {
-                // we didn't find an interval, assuming we are past the end
-                timeline.last().map(|t| (t.x.unwrap_or(1.0) as f32, t.y.unwrap_or(1.0) as f32))
-                    .unwrap_or((1.0, 1.0))
-            }
-        }
-
-    } else {
-        // we have no timeline
-        (1.0, 1.0)
-    };
-
-    
-    // returning
-    Ok(BoneData {
-        position: position,
-        rotation: rotation,
-        scale: scale,
-    })
-}
-
-/// Calculates a curve using the value of a "curve" member.
-///
-/// Position must be between 0 and 1
-fn calculate_curve(formula: &Option<format::TimelineCurve>, from: f32, to: f32,
-    position: f32) -> Result<f32, CalculationError>
-{
-    assert!(position >= 0.0 && position <= 1.0);
-
-    let bezier = match formula {
-        &None =>
-            return Ok(from + position * (to - from)),
-        &Some(format::TimelineCurve::CurvePredefined(ref a)) if a == "linear" =>
-            return Ok(from + position * (to - from)),
-        &Some(format::TimelineCurve::CurvePredefined(ref a)) if a == "stepped" =>
-            return Ok(from),
-        &Some(format::TimelineCurve::CurveBezier(ref a)) => &a[..],
-        a => return Err(CalculationError::UnknownCurveFunction(format!("{:?}", a))),
-    };
-    
-    let (cx1, cy1, cx2, cy2) = match (bezier.get(0), bezier.get(1),
-                                      bezier.get(2), bezier.get(3))
-    {
-        (Some(&cx1), Some(&cy1), Some(&cx2), Some(&cy2)) =>
-            (cx1 as f32, cy1 as f32, cx2 as f32, cy2 as f32),
-        a =>
-            return Err(CalculationError::UnknownCurveFunction(format!("{:?}", a)))
-    };
-
-    let factor = (0 ..).map(|v| v as f32 * 0.02)
-        .take_while(|v| *v <= 1.0)
-        .map(|t| {
-            let x = 3.0 * cx1 * t * (1.0 - t) * (1.0 - t)
-                + 3.0 * cx2 * t * t * (1.0 - t) + t * t * t;
-            let y = 3.0 * cy1 * t * (1.0 - t) * (1.0 - t)
-                + 3.0 * cy2 * t * t * (1.0 - t) + t * t * t;
-
-            (x, y)
-        })
-        .scan((0.0, 0.0), |previous, current| {
-            let result = Some((previous.clone(), current));
-            *previous = current;
-            result
-        })
-        .find(|&(previous, current)| {
-            position >= previous.0 && position < current.0
-        })
-        .map(|((_, val), _)| val)
-        .unwrap_or(1.0);
-
-    Ok(from + factor * (to - from))
-}
-
-/// Builds the color and attachment corresponding to a slot timeline.
-fn timelines_to_slotdata(timeline: &format::SlotTimeline, elapsed: f32)
-    -> Result<(Option<&str>, Option<&str>), CalculationError>
-{
-    // calculating the attachment
-    let attachment = if let Some(timeline) = timeline.attachment.as_ref() {
-        // finding in which interval we are
-        match timeline.iter().zip(timeline.iter().skip(1))
-            .find(|&(before, after)| elapsed >= before.time as f32 && elapsed < after.time as f32)
-        {
-            Some((ref before, _)) => {
-                before.name.as_ref().map(|e| &e[..])
-            },
-            None => {
-                // we didn't find an interval, assuming we are past the end
-                timeline.last().and_then(|t| (t.name.as_ref().map(|e| &e[..])))
-            }
-        }
-
-    } else {
-        // we have no timeline
-        None
-    };
-
-
-    // calculating the color
-    let color = if let Some(timeline) = timeline.color.as_ref() {
-        // finding in which interval we are
-        match timeline.iter().zip(timeline.iter().skip(1))
-            .find(|&(before, after)| elapsed >= before.time as f32 && elapsed < after.time as f32)
-        {
-            Some((ref before, _)) => {
-                before.color.as_ref().map(|e| &e[..])
-            },
-            None => {
-                // we didn't find an interval, assuming we are past the end
-                timeline.last().and_then(|t| (t.color.as_ref().map(|e| &e[..])))
-            }
-        }
-
-    } else {
-        // we have no timeline
-        None
-    };
-
-    
-    // returning
-    Ok((color, attachment))
-}
+extern crate rustc_serialize as serialize;
+
+mod json;
+pub mod skeleton;
+pub mod atlas;

--- a/src/skeleton/animation.rs
+++ b/src/skeleton/animation.rs
@@ -1,0 +1,227 @@
+//! Module to interpolate animated sprites
+
+use skeleton;
+use skeleton::error::SkeletonError;
+use std::collections::HashMap;
+use std::slice::Iter;
+
+/// Wrapper on attachment depending whether slot attachment is animated or not
+enum AttachmentWrapper<'a> {
+    Static(Option<&'a skeleton::Attachment>),
+    Dynamic(Option<&'a skeleton::Attachment>, HashMap<&'a str, Option<&'a skeleton::Attachment>>),
+}
+
+/// Struct to handle animated skin and calculate sprites
+pub struct SkinAnimation<'a> {
+    anim_bones: Vec<(&'a skeleton::Bone, Option<&'a skeleton::timelines::BoneTimeline>)>,
+    anim_slots: Vec<(&'a skeleton::Slot, AttachmentWrapper<'a>, Option<&'a skeleton::timelines::SlotTimeline>)>,
+    duration: f32
+}
+
+/// Interpolated slot with attachment and color
+#[derive(Debug)]
+pub struct Sprite<'a> {
+    /// attachment name
+    pub attachment: &'a str,
+    /// color
+    pub color: [u8; 4],
+    /// srt
+    pub srt: skeleton::SRT
+}
+
+impl<'a> SkinAnimation<'a> {
+
+    /// Iterator<Item=Vec<CalculatedSlot>> where item are modified with timelines
+    pub fn new(skeleton: &'a skeleton::Skeleton, skin: &str, animation: Option<&str>)
+        -> Result<SkinAnimation<'a>, SkeletonError>
+    {
+        // search all attachments defined by the skin name (use 'default' skin if not found)
+        let skin = try!(skeleton.get_skin(skin));
+        let default_skin = try!(skeleton.get_skin("default"));
+
+        // get animation
+        let (animation, duration) = if let Some(animation) = animation {
+            let anim = try!(skeleton.animations.get(animation)
+                .ok_or_else(|| SkeletonError::AnimationNotFound(animation.to_owned())));
+            (Some(anim), anim.duration)
+        } else {
+            (None, 0f32)
+        };
+
+        // get bone related data
+        let anim_bones = skeleton.bones.iter().enumerate().map(|(i, b)|
+            (b, animation.and_then(|anim| anim.bones.iter()
+                .find(|&&(idx, _)| idx == i).map(|&(_, ref a)| a)))).collect();
+
+        let find_attach = |i: usize, name: &str| skin.find(i, name).or_else(|| default_skin.find(i, name));
+
+        // get slot related data
+        let anim_slots = skeleton.slots.iter().enumerate().map(|(i, s)| {
+
+            let anim = animation.and_then(|anim|
+                anim.slots.iter().find(|&&(idx, _)| idx == i ).map(|&(_, ref anim)| anim));
+
+            let slot_attach = s.attachment.as_ref().and_then(|name| find_attach(i, &name));
+            let attach = match anim.map(|anim| anim.get_attachment_names()) {
+                Some(names) => {
+                    if names.is_empty() {
+                         AttachmentWrapper::Static(slot_attach)
+                    } else {
+                        let attachments = names.iter().map(|&name|(name, find_attach(i, name))).collect();
+                        AttachmentWrapper::Dynamic(slot_attach, attachments)
+                    }
+                },
+                None => AttachmentWrapper::Static(slot_attach)
+            };
+            (s, attach, anim)
+        }).collect();
+
+        Ok(SkinAnimation {
+            duration: duration,
+            anim_bones: anim_bones,
+            anim_slots: anim_slots,
+        })
+    }
+
+    /// Gets duration of the longest timeline in the animation
+    pub fn get_duration(&self) -> f32 {
+        self.duration
+    }
+
+    /// gets all bones srts at given time
+    fn get_bones_srts(&self, time: f32) -> Vec<skeleton::SRT> {
+
+        let mut srts: Vec<skeleton::SRT> = Vec::with_capacity(self.anim_bones.len());
+        for &(b, anim) in &self.anim_bones {
+
+            // starts with setup pose
+            let mut srt = b.srt.clone();
+            let mut rotation = 0.0;
+
+            // add animation srt
+            if let Some(anim_srt) = anim.map(|anim| anim.srt(time)) {
+                srt.position[0] += anim_srt.position[0];
+                srt.position[1] += anim_srt.position[1];
+                rotation += anim_srt.rotation;
+                srt.scale[0] *= anim_srt.scale[0];
+                srt.scale[1] *= anim_srt.scale[1];
+            }
+
+            // inherit world from parent srt
+            if let Some(ref parent_srt) = b.parent_index.and_then(|p| srts.get(p)) {
+                srt.position = parent_srt.transform(srt.position);
+                if b.inherit_rotation {
+                    rotation += parent_srt.rotation;
+                }
+                if b.inherit_scale {
+                    srt.scale[0] *= parent_srt.scale[0];
+                    srt.scale[1] *= parent_srt.scale[1];
+                }
+            }
+
+            // re-calculate sin/cos only if rotation has changed
+            if rotation != 0.0 {
+                srt.rotation += rotation;
+                srt.cos = srt.rotation.cos();
+                srt.sin = srt.rotation.sin();
+            }
+            srts.push(srt)
+        }
+        srts
+    }
+
+    /// Interpolates animated slots at given time
+    pub fn interpolate<'b: 'a>(&'b self, time: f32) -> Option<Sprites<'b>> {
+
+        if time > self.duration {
+            return None;
+        }
+
+        let srts = self.get_bones_srts(time);
+        let iter = self.anim_slots.iter();
+        Some(Sprites {
+            iter: iter,
+            srts: srts,
+            time: time
+        })
+    }
+
+    /// Creates an iterator which iterates sprites at delta seconds interval
+    pub fn run<'b: 'a>(&'b self, delta: f32) -> AnimationIter<'b> {
+        AnimationIter {
+            skin_animation: &self,
+            time: 0f32,
+            delta: delta
+        }
+    }
+}
+
+/// Iterator over all sprites interpolated at a given time
+pub struct Sprites<'a> {
+    iter: Iter<'a, (&'a skeleton::Slot, AttachmentWrapper<'a>, Option<&'a skeleton::timelines::SlotTimeline>)>,
+    srts: Vec<skeleton::SRT>,
+    time: f32
+}
+
+impl<'a> Iterator for Sprites<'a> {
+    type Item = Sprite<'a>;
+    fn next<'b>(&'b mut self) -> Option<Sprite<'a>> {
+
+        while let Some(&(slot, ref skin_attach, anim)) = self.iter.next() {
+
+            // search animated attachment
+            let (name, skin_attach) = match *skin_attach {
+                AttachmentWrapper::Static(ref attach) => (None, attach),
+                AttachmentWrapper::Dynamic(ref attach, ref names) => {
+                    match anim.unwrap().interpolate_attachment(self.time) {
+                        Some(Some(name)) => {
+                            let attach = names.get(&*name).unwrap();
+                            (Some(name), attach)
+                        },
+                        Some(None) => (None, attach),
+                        None => (None, attach),
+                    }
+                }
+            };
+
+            // nothing to show if there is no attachment
+            if let Some(ref skin_attach) = *skin_attach {
+
+                // color
+                let color = anim.map(|anim| anim.interpolate_color(self.time))
+                            .unwrap_or(slot.color.clone());
+
+                // attachment name
+                let attach_name = name.or(skin_attach.name.as_ref()
+                                      .or(slot.attachment.as_ref()).map(|n| &**n))
+                                  .expect("no attachment name provided");
+
+                return Some(Sprite {
+                    attachment: attach_name,
+                    srt: self.srts[slot.bone_index].clone(),
+                    color: color
+                })
+            }
+        }
+
+        // end of iter
+        None
+    }
+}
+
+/// Iterator over a constant period
+#[derive(Clone)]
+pub struct AnimationIter<'a> {
+    skin_animation: &'a SkinAnimation<'a>,
+    time: f32,
+    delta: f32
+}
+
+impl<'a> Iterator for AnimationIter<'a> {
+    type Item = Sprites<'a>;
+    fn next(&mut self) -> Option<Sprites<'a>> {
+        let result = self.skin_animation.interpolate(self.time);
+        self.time += self.delta;
+        result
+    }
+}

--- a/src/skeleton/error.rs
+++ b/src/skeleton/error.rs
@@ -1,0 +1,84 @@
+//! Module to handle all spine errors
+
+use serialize::hex::FromHexError;
+use serialize::json::ParserError;
+use from_json::FromJsonError;
+use std::fmt;
+use std::error::Error;
+
+/// Error that can happen while calculating an animation.
+pub enum SkeletonError {
+
+    /// Parser error
+    ParserError(ParserError),
+
+    /// Parser error
+    FromJsonError(FromJsonError),
+
+    /// The requested bone was not found.
+    BoneNotFound(String),
+
+    /// The requested slot was not found.
+    SlotNotFound(String),
+
+    /// The requested slot was not found.
+    SkinNotFound(String),
+
+    /// The requested slot was not found.
+    InvalidColor(FromHexError),
+
+    /// The requested animation was not found.
+    AnimationNotFound(String),
+}
+
+impl fmt::Debug for SkeletonError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            SkeletonError::BoneNotFound(ref name) => write!(f, "Cannot find bone '{}'", name),
+            SkeletonError::SlotNotFound(ref name) => write!(f, "Cannot find slot '{}'", name),
+            SkeletonError::SkinNotFound(ref name) => write!(f, "Cannot find skin '{}'", name),
+            SkeletonError::AnimationNotFound(ref name) => write!(f, "Cannot find animation '{}'", name),
+            SkeletonError::InvalidColor(ref e)  => write!(f, "Cannot convert color to hexadecimal: {:?}", e),
+            SkeletonError::FromJsonError(ref e) => write!(f, "Cannot deserialize from json: {:?}", e),
+            SkeletonError::ParserError(ref e)   => write!(f, "Cannot deserialize from json: {:?}", e),
+        }
+    }
+}
+
+impl fmt::Display for SkeletonError {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self, formatter)
+    }
+}
+
+impl Error for SkeletonError {
+    fn description(&self) -> &str {
+        match *self {
+            SkeletonError::BoneNotFound(_) => "bone cannot be found in skeleton bones",
+            SkeletonError::SlotNotFound(_) => "slot cannot be found in skeleton slots",
+            SkeletonError::SkinNotFound(_) => "skin cannot be found in skeleton skins",
+            SkeletonError::InvalidColor(_) => "color cannot be parsed",
+            SkeletonError::AnimationNotFound(_) => "animation cannot be found in skeleton animations",
+            SkeletonError::FromJsonError(_) => "error while parsing json skeleton",
+            SkeletonError::ParserError(_) => "error while parsing json skeleton",
+        }
+    }
+}
+
+impl From<FromHexError> for SkeletonError {
+    fn from(error: FromHexError) -> SkeletonError {
+        SkeletonError::InvalidColor(error)
+    }
+}
+
+impl From<ParserError> for SkeletonError {
+    fn from(error: ParserError) -> SkeletonError {
+        SkeletonError::ParserError(error)
+    }
+}
+
+impl From<FromJsonError> for SkeletonError {
+    fn from(error: FromJsonError) -> SkeletonError {
+        SkeletonError::FromJsonError(error)
+    }
+}

--- a/src/skeleton/mod.rs
+++ b/src/skeleton/mod.rs
@@ -1,0 +1,374 @@
+//! Skeleton structs
+//! Owns json::Animation
+
+pub mod error;
+mod timelines;
+pub mod animation;
+
+use json;
+use from_json;
+use std::collections::HashMap;
+use std::io::Read;
+use std::f32::consts::PI;
+use serialize::hex::{FromHex, FromHexError};
+
+// Reexport skeleton modules
+use self::error::SkeletonError;
+use self::timelines::{BoneTimeline, SlotTimeline};
+use self::animation::SkinAnimation;
+
+const TO_RADIAN: f32 = PI / 180f32;
+
+fn bone_index(name: &str, bones: &[Bone]) -> Result<usize, SkeletonError> {
+    bones.iter().position(|b| b.name == *name).ok_or_else(|| SkeletonError::BoneNotFound(name.to_owned()))
+}
+
+fn slot_index(name: &str, slots: &[Slot]) -> Result<usize, SkeletonError> {
+    slots.iter().position(|b| b.name == *name).ok_or_else(|| SkeletonError::SlotNotFound(name.to_owned()))
+}
+
+/// Skeleton data converted from json and loaded into memory
+pub struct Skeleton {
+    /// bones for the skeleton, hierarchically ordered
+    bones: Vec<Bone>,
+    /// slots
+    slots: Vec<Slot>,
+    /// skins : key: skin name, value: slots attachments
+    skins: HashMap<String, Skin>,
+    /// all the animations
+    animations: HashMap<String, Animation>
+}
+
+impl Skeleton {
+
+    /// Consumes reader (with json data) and returns a skeleton wrapping
+    pub fn from_reader<R: Read>(mut reader: R) -> Result<Skeleton, SkeletonError> {
+
+        // read and convert as json
+        let document = try!(from_json::Json::from_reader(&mut reader));
+        let document: json::Document = try!(from_json::FromJson::from_json(&document));
+
+        // convert to skeleton (consumes document)
+        Skeleton::from_json(document)
+    }
+
+    /// Creates a from_json skeleton
+    /// Consumes json::Document
+    fn from_json(doc: json::Document) -> Result<Skeleton, SkeletonError> {
+
+        let mut bones = Vec::new();
+        if let Some(jbones) = doc.bones {
+            for b in jbones.into_iter() {
+                let bone = try!(Bone::from_json(b, &bones));
+                bones.push(bone);
+            }
+        }
+
+        let mut slots = Vec::new();
+        if let Some(jslots) = doc.slots {
+            for s in jslots.into_iter() {
+                let slot = try!(Slot::from_json(s, &bones));
+                slots.push(slot);
+            }
+        }
+
+        let mut animations = HashMap::new();
+        for janimations in doc.animations.into_iter() {
+            for (name, animation) in janimations.into_iter() {
+                let animation = try!(Animation::from_json(animation, &bones, &slots));
+                animations.insert(name, animation);
+            }
+        }
+
+        let mut skins = HashMap::new();
+        for jskin in doc.skins.into_iter() {
+            for (name, jslots) in jskin.into_iter() {
+                let mut skin = Vec::new();
+                for (name, attachments) in jslots.into_iter() {
+                    let slot_index = try!(slot_index(&name, &slots));
+                    let attachments = attachments.into_iter().map(|(name, attachment)| {
+                        (name, Attachment::from_json(attachment))
+                     }).collect();
+                    skin.push((slot_index, attachments));
+                }
+                skins.insert(name, Skin {
+                    slots: skin
+                });
+            }
+        }
+
+        Ok(Skeleton {
+            bones: bones,
+            slots: slots,
+            skins: skins,
+            animations: animations
+        })
+    }
+
+    /// get skin
+    pub fn get_skin<'a>(&'a self, name: &str) -> Result<&'a Skin, SkeletonError> {
+        self.skins.get(name).ok_or_else(|| SkeletonError::SkinNotFound(name.to_owned()))
+    }
+
+    /// Gets a SkinAnimation which can interpolate slots at a given time
+    pub fn get_animated_skin<'a>(&'a self, skin: &str, animation: Option<&str>)
+        -> Result<SkinAnimation<'a>, SkeletonError>
+    {
+        SkinAnimation::new(self, skin, animation)
+    }
+
+    /// Returns the list of all skins names in this document.
+    pub fn get_skins_names(&self) -> Vec<&str> {
+        self.skins.keys().map(|k| &**k).collect()
+    }
+
+    /// Returns the list of all animations names in this document.
+    pub fn get_animations_names(&self) -> Vec<&str> {
+        self.animations.keys().map(|k| &**k).collect()
+    }
+
+    /// Returns the list of all attachment names in all skins in this document.
+    ///
+    /// The purpose of this function is to allow you to preload what you need.
+    pub fn get_attachments_names(&self) -> Vec<&str> {
+        let mut names: Vec<_> = self.skins.values()
+            .flat_map(|skin| skin.slots.iter()
+                .flat_map(|&(_, ref attach)| attach.iter()
+                    .map(|(k, v)| v.name.as_ref().map(|n| &**n).unwrap_or(&*k))))
+            .collect();
+
+        names.sort();
+        names.dedup();
+        names
+    }
+}
+
+/// Skin
+/// defines a set of slot with custom attachments
+/// slots: Vec<(slot_index, HashMap<custom_attachment_name, Attachment>)>
+/// TODO: simpler architecture
+pub struct Skin {
+    /// all slots modified by the skin, the default skin contains all skeleton bones
+    slots: Vec<(usize, HashMap<String, Attachment>)>
+}
+
+impl Skin {
+    /// find attachment in a skin
+    fn find(&self, slot_index: usize, attach_name: &str) -> Option<&Attachment> {
+        self.slots.iter().filter_map(|&(i, ref attachs)|
+            if i == slot_index {
+                attachs.get(attach_name)
+            } else {
+                None
+            }).next()
+    }
+
+    /// get all attachments and their positions to setup the skeleton's skin
+    pub fn attachment_positions(&self) -> Vec<(&str, &[[f32; 2]; 4])> {
+        self.slots.iter().flat_map(|&(_, ref attachs)|
+            attachs.iter().map(|(name, ref attach)| (&**name, &attach.positions))).collect()
+    }
+}
+
+/// Animation with precomputed data
+struct Animation {
+    bones: Vec<(usize, BoneTimeline)>,
+    slots: Vec<(usize, SlotTimeline)>,
+    events: Vec<json::EventKeyframe>,
+    draworder: Vec<json::DrawOrderTimeline>,
+    duration: f32
+}
+
+impl Animation {
+
+    /// Creates a from_json Animation
+    fn from_json(animation: json::Animation, bones: &[Bone], slots: &[Slot])
+        -> Result<Animation, SkeletonError>
+    {
+        let duration = Animation::duration(&animation);
+
+        let mut abones = Vec::new();
+        for jbones in animation.bones.into_iter() {
+            for (name, timelines) in jbones.into_iter() {
+                let index = try!(bone_index(&name, bones));
+                let timeline = try!(BoneTimeline::from_json(timelines));
+                abones.push((index, timeline));
+            }
+        }
+
+        let mut aslots = Vec::new();
+        for jslots in animation.slots.into_iter() {
+            for (name, timelines) in jslots.into_iter() {
+                let index = try!(slot_index(&name, slots));
+                let timeline = try!(SlotTimeline::from_json(timelines));
+                aslots.push((index, timeline));
+            }
+        }
+
+        Ok(Animation {
+            duration: duration,
+            bones: abones,
+            slots: aslots,
+            events: animation.events.unwrap_or(Vec::new()),
+            draworder: animation.draworder.unwrap_or(Vec::new()),
+        })
+    }
+
+    fn duration(animation: &json::Animation) -> f32 {
+        animation.bones.iter().flat_map(|bones| bones.values().flat_map(|timelines|{
+            timelines.translate.iter().flat_map(|translate| translate.iter().map(|e| e.time))
+            .chain(timelines.rotate.iter().flat_map(|rotate| rotate.iter().map(|e| e.time)))
+            .chain(timelines.scale.iter().flat_map(|scale| scale.iter().map(|e| e.time)))
+        }))
+        .chain(animation.slots.iter().flat_map(|slots| slots.values().flat_map(|timelines|{
+            timelines.attachment.iter().flat_map(|attachment| attachment.iter().map(|e| e.time))
+            .chain(timelines.color.iter().flat_map(|color| color.iter().map(|e| e.time)))
+        })))
+        .fold(0.0f32, f32::max)
+    }
+}
+
+/// Scale, Rotate, Translate struct
+#[derive(Debug, Clone)]
+pub struct SRT {
+    /// scale
+    pub scale: [f32; 2],
+    /// rotation in radians
+    pub rotation: f32,
+    /// position or translation
+    pub position: [f32; 2],
+    /// cosinus
+    pub cos: f32,
+    /// sinus
+    pub sin: f32
+}
+
+impl SRT {
+
+    /// new srt
+    pub fn new(scale_x: f32, scale_y: f32, rotation_deg: f32, x: f32, y: f32) -> SRT {
+        let rotation = rotation_deg * TO_RADIAN;
+        SRT {
+            scale: [scale_x, scale_y],
+            rotation: rotation,
+            position: [x, y],
+            cos: rotation.cos(),
+            sin: rotation.sin()
+        }
+    }
+
+    /// apply srt on a 2D point (consumes the point)
+    pub fn transform(&self, v: [f32; 2]) -> [f32; 2] {
+        [self.cos * v[0] * self.scale[0] - self.sin * v[1] * self.scale[1] + self.position[0],
+         self.sin * v[0] * self.scale[0] + self.cos * v[1] * self.scale[1] + self.position[1]]
+    }
+
+    /// convert srt to a 3x3 transformation matrix (2D)
+    pub fn to_matrix3(&self) -> [[f32; 3]; 3] {
+        [
+            [ self.cos * self.scale[0], self.sin, 0.0],
+            [-self.sin, self.cos * self.scale[1], 0.0],
+            [ self.position[0] , self.position[1], 1.0f32],
+        ]
+    }
+
+    /// convert srt to a 4x4 transformation matrix (3D)
+    pub fn to_matrix4(&self) -> [[f32; 4]; 4] {
+        [
+            [ self.cos * self.scale[0], self.sin, 0.0, 0.0],
+            [-self.sin, self.cos * self.scale[1], 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+            [ self.position[0] , self.position[1], 0.0, 1.0f32],
+        ]
+    }
+
+}
+
+/// skeleton bone
+struct Bone {
+    name: String,
+    parent_index: Option<usize>,
+    // length: f32,
+    srt: SRT,
+    inherit_scale: bool,
+    inherit_rotation: bool
+}
+
+impl Bone {
+    fn from_json(bone: json::Bone, bones: &[Bone]) -> Result<Bone, SkeletonError> {
+        let index = match bone.parent {
+            Some(ref name) => Some(try!(bone_index(name, bones))),
+            None => None
+        };
+        Ok(Bone {
+            name: bone.name,
+            parent_index: index,
+            // length: bone.length.unwrap_or(0f32),
+            srt: SRT::new(bone.scale_x.unwrap_or(1.0), bone.scale_y.unwrap_or(1.0),
+                bone.rotation.unwrap_or(0.0), bone.x.unwrap_or(0.0), bone.y.unwrap_or(0.0)),
+            inherit_scale: bone.inherit_scale.unwrap_or(true),
+            inherit_rotation: bone.inherit_rotation.unwrap_or(true),
+        })
+    }
+}
+
+/// skeleton slot
+struct Slot {
+    name: String,
+    bone_index: usize,
+    color: [u8; 4],
+    attachment: Option<String>
+}
+
+impl Slot {
+    fn from_json(slot: json::Slot, bones: &[Bone]) -> Result<Slot, SkeletonError> {
+        let bone_index = try!(bone_index(&slot.bone, &bones));
+        let color = match slot.color {
+            Some(c) => {
+                let v = try!(c.from_hex());
+                if v.len() != 4 {
+                    return Err(SkeletonError::InvalidColor(FromHexError::InvalidHexLength));
+                }
+                [v[0], v[1], v[2], v[3]]
+            },
+            None => [255, 255, 255, 255]
+        };
+
+        Ok(Slot {
+            name: slot.name,
+            bone_index: bone_index,
+            color: color,
+            attachment: slot.attachment
+        })
+    }
+}
+
+/// skeletom animation
+#[derive(Debug)]
+struct Attachment {
+    name: Option<String>,
+    type_: json::AttachmentType,
+    positions: [[f32; 2]; 4]
+    // fps: Option<f32>,
+    // mode: Option<String>,
+    //vertices: Option<Vec<??>>     // TODO: ?
+}
+
+impl Attachment {
+    /// converts json data into skeleton data
+    fn from_json(attachment: json::Attachment) -> Attachment {
+        let srt = SRT::new(attachment.scale_x.unwrap_or(1.0), attachment.scale_y.unwrap_or(1.0),
+                           attachment.rotation.unwrap_or(0.0),
+                           attachment.x.unwrap_or(0.0), attachment.y.unwrap_or(0.0));
+        let (w2, h2) = (attachment.width.unwrap_or(0f32) / 2.0,
+                        attachment.height.unwrap_or(0f32) / 2.0);
+        Attachment {
+            name: attachment.name,
+            type_: attachment.type_.unwrap_or(json::AttachmentType::Region),
+            positions: [srt.transform([-w2,  h2]),
+                        srt.transform([w2,  h2]),
+                        srt.transform([w2,  -h2]),
+                        srt.transform([-w2,  -h2])]
+        }
+    }
+}

--- a/src/skeleton/timelines.rs
+++ b/src/skeleton/timelines.rs
@@ -1,0 +1,279 @@
+use json;
+use skeleton;
+use serialize::hex::{FromHex, FromHexError};
+use skeleton::error::SkeletonError;
+
+const BEZIER_SEGMENTS: usize = 10;
+
+trait Interpolate {
+    fn interpolate(&self, next: &Self, percent: f32) -> Self;
+}
+
+impl Interpolate for f32 {
+    fn interpolate(&self, next: &Self, percent: f32) -> Self {
+        *self + percent * (*next - *self)
+    }
+}
+
+impl Interpolate for (f32, f32) {
+    fn interpolate(&self, next: &Self, percent: f32) -> Self {
+        (self.0 + percent * (next.0 - self.0), self.1 + percent * (next.1 - self.1))
+    }
+}
+
+impl Interpolate for [u8; 4] {
+    fn interpolate(&self, next: &Self, percent: f32) -> Self {
+        [(self[0] as f32).interpolate(&(next[0] as f32), percent) as u8,
+         (self[1] as f32).interpolate(&(next[1] as f32), percent) as u8,
+         (self[2] as f32).interpolate(&(next[2] as f32), percent) as u8,
+         (self[3] as f32).interpolate(&(next[3] as f32), percent) as u8]
+    }
+}
+
+/// Curve trait to define struct with curve property (unwrapped to Linear)
+trait Curve<T> {
+    fn time(&self) -> f32;
+    fn curve(&self) -> json::TimelineCurve;
+    fn value(&self) -> Result<T, SkeletonError>;
+}
+
+/// Macro rule to implement curve based on json structs
+/// The only non trivial property is the `value`
+macro_rules! impl_curve {
+    ($to:ty, $from:ty, $f:expr) => {
+        impl Curve<$from> for $to {
+            fn time(&self) -> f32 {
+                self.time
+            }
+            fn curve(&self) -> json::TimelineCurve {
+                self.curve.clone().unwrap_or(json::TimelineCurve::CurveLinear)
+            }
+            fn value(&self) -> Result<$from, SkeletonError> {
+                $f(&self)
+            }
+        }
+    }
+}
+
+impl_curve!(json::BoneTranslateTimeline, (f32, f32), |t: &json::BoneTranslateTimeline| {
+    Ok((t.x.unwrap_or(0f32), t.y.unwrap_or(0f32)))
+});
+
+impl_curve!(json::BoneScaleTimeline, (f32, f32), |t: &json::BoneScaleTimeline| {
+    Ok((t.x.unwrap_or(1f32), t.y.unwrap_or(1f32)))
+});
+
+impl_curve!(json::BoneRotateTimeline, f32, |t: &json::BoneRotateTimeline| {
+    let mut angle = t.angle.unwrap_or(0f32);
+    while angle > 180.0 { angle -= 360.0; }
+    while angle < -180.0 { angle += 360.0; }
+    Ok(angle)
+});
+
+impl_curve!(json::SlotColorTimeline, [u8; 4], |t: &json::SlotColorTimeline| {
+    Ok(match t.color {
+        Some(ref c) => {
+            let v = try!(c.from_hex());
+            if v.len() != 4 {
+                return Err(SkeletonError::InvalidColor(FromHexError::InvalidHexLength));
+            }
+            [v[0], v[1], v[2], v[3]]
+        },
+        None => [255, 255, 255, 255]
+    })
+});
+
+impl Curve<Option<String>> for json::SlotAttachmentTimeline {
+    fn time(&self) -> f32 {
+        self.time
+    }
+    fn curve(&self) -> json::TimelineCurve {
+        json::TimelineCurve::CurveStepped
+    }
+    fn value(&self) -> Result<Option<String>, SkeletonError> {
+        Ok(self.name.clone())
+    }
+}
+
+struct CurveTimeline<T> {
+    time: f32,
+    curve: json::TimelineCurve,
+    points: Option<(Vec<f32>, Vec<f32>)>,    // bezier curve interpolations points
+    value: T,
+}
+
+impl<T> CurveTimeline<T> {
+
+    /// interpolation values (x, y)
+    /// Sets the control handle positions for an interpolation bezier curve used to transition
+    /// from this keyframe to the next.
+    /// cx1 and cx2 are from 0 to 1, representing the percent of time between the two keyframes.
+    /// cy1 and cy2 are the percent of the difference between the keyframe's values.
+    fn compute_points(curve: &json::TimelineCurve) -> Option<(Vec<f32>, Vec<f32>)> {
+
+        let (cx1, cy1, cx2, cy2) = match *curve {
+            json::TimelineCurve::CurveStepped |
+            json::TimelineCurve::CurveLinear  => return None, // no interpolation: early return
+            json::TimelineCurve::CurveBezier(ref p)  => (p[0], p[1], p[2], p[3])
+        };
+
+        let subdiv1 = 1f32 / BEZIER_SEGMENTS as f32;
+        let subdiv2 = subdiv1 * subdiv1;
+        let subdiv3 = subdiv2 * subdiv1;
+        let (pre1, pre2, pre4, pre5) = (3f32 * subdiv1, 3f32 * subdiv2, 6f32 * subdiv2, 6f32 * subdiv3);
+        let (tmp1x, tmp1y) = (-cx1 * 2f32 + cx2, -cy1 * 2f32 + cy2);
+        let (tmp2x, tmp2y) = ((cx1 - cx2) * 3f32 + 1f32, (cy1 - cy2) * 3f32 + 1f32);
+        let mut dfx = cx1 * pre1 + tmp1x * pre2 + tmp2x * subdiv3;
+        let mut dfy = cy1 * pre1 + tmp1y * pre2 + tmp2y * subdiv3;
+        let (mut ddfx, mut ddfy) = (tmp1x * pre4 + tmp2x * pre5, tmp1y * pre4 + tmp2y * pre5);
+        let (dddfx, dddfy) = (tmp2x * pre5, tmp2y * pre5);
+
+        let (mut vec_x, mut vec_y) = (Vec::with_capacity(BEZIER_SEGMENTS), Vec::with_capacity(BEZIER_SEGMENTS));
+        let (mut x, mut y) = (dfx, dfy);
+        for _ in 0..BEZIER_SEGMENTS {
+            vec_x.push(x);
+            vec_y.push(y);
+            dfx += ddfx;
+            dfy += ddfy;
+            ddfx += dddfx;
+            ddfy += dddfy;
+            x += dfx;
+            y += dfy;
+        }
+        Some((vec_x, vec_y))
+    }
+
+    /// Get percent conversion depending on curve type
+    fn get_percent(&self, percent: f32) -> f32 {
+
+
+        let &(ref x,  ref y) = match self.curve {
+            json::TimelineCurve::CurveStepped    => return 0f32,
+            json::TimelineCurve::CurveLinear     => return percent,
+            json::TimelineCurve::CurveBezier(..) => self.points.as_ref().unwrap()
+        };
+
+        // bezier curve
+        match x.iter().position(|&xi| percent < xi) {
+            Some(0) => y[0] * percent / x[0],
+            Some(i) => y[i] + (y[i] - y[i - 1]) * (percent - x[i - 1]) / (x[i] - x[i - 1]),
+            None => {
+                let (x, y) = (x[BEZIER_SEGMENTS - 1], y[BEZIER_SEGMENTS - 1]);
+                y + (1f32 - y) * (percent - x) / (1f32 - x)
+            }
+        }
+    }
+}
+
+/// Set of timelines
+struct CurveTimelines<T> {
+    timelines: Vec<CurveTimeline<T>>
+}
+
+impl<T: Interpolate + Clone> CurveTimelines<T> {
+
+    /// Converts vector of json timelines to vector or timelines
+    fn from_json_vec<U: Curve<T>> (jtimelines: Option<Vec<U>>) -> Result<CurveTimelines<T>, SkeletonError>
+    {
+    	match jtimelines {
+    	    None => Ok(CurveTimelines { timelines: Vec::new() }),
+    	    Some(timelines) => {
+    	        let mut curves = Vec::with_capacity(timelines.len());
+    	        for t in timelines.into_iter() {
+    	            let value = try!(t.value());
+    	            let curve = t.curve();
+    	            let points = CurveTimeline::<T>::compute_points(&curve);
+    	            curves.push(CurveTimeline {
+    	                time: t.time(),
+                        curve: curve,
+                        value: value,
+                        points: points
+    	            });
+    	        }
+    	        Ok(CurveTimelines { timelines: curves })
+    	    }
+    	}
+    }
+
+    /// interpolates `value` in the interval containing elapsed
+    fn interpolate(&self, elapsed: f32) -> Option<T> {
+    	if self.timelines.is_empty() || elapsed < self.timelines[0].time {
+    	    return None;
+    	}
+
+    	if let Some(w) = self.timelines.windows(2).find(|&w| elapsed < w[1].time) {
+    	    let percent = (elapsed - w[0].time) / (w[1].time - w[0].time);
+    	    let curve_percent = w[0].get_percent(percent);
+    	    Some(w[0].value.interpolate(&w[1].value, curve_percent))
+    	} else {
+    	    Some(self.timelines[self.timelines.len() - 1].value.clone())
+    	}
+    }
+}
+
+pub struct BoneTimeline {
+    translate: CurveTimelines<(f32, f32)>,
+    rotate: CurveTimelines<f32>,
+    scale: CurveTimelines<(f32, f32)>,
+}
+
+impl BoneTimeline {
+
+    /// converts json data into BoneTimeline
+    pub fn from_json(json: json::BoneTimeline)
+        -> Result<BoneTimeline, skeleton::error::SkeletonError>
+    {
+        let translate = try!(CurveTimelines::from_json_vec(json.translate));
+        let rotate = try!(CurveTimelines::from_json_vec(json.rotate));
+        let scale = try!(CurveTimelines::from_json_vec(json.scale));
+        Ok(BoneTimeline {
+            translate: translate,
+            rotate: rotate,
+            scale: scale,
+        })
+    }
+
+    /// evaluates the interpolations for elapsed time on all timelines and
+    /// returns the corresponding srt
+    pub fn srt(&self, elapsed: f32) -> skeleton::SRT {
+    	let (x, y) = self.translate.interpolate(elapsed).unwrap_or((0f32, 0f32));
+    	let rotation = self.rotate.interpolate(elapsed).unwrap_or(0f32);
+    	let (scale_x, scale_y) = self.scale.interpolate(elapsed).unwrap_or((1.0, 1.0));
+    	skeleton::SRT::new(scale_x, scale_y, rotation, x, y)
+    }
+}
+
+pub struct SlotTimeline {
+    attachment: Vec<json::SlotAttachmentTimeline>,
+    color: CurveTimelines<[u8; 4]>,
+}
+
+impl SlotTimeline {
+
+    pub fn from_json(json: json::SlotTimeline) -> Result<SlotTimeline, SkeletonError> {
+        let color = try!(CurveTimelines::from_json_vec(json.color));
+        Ok(SlotTimeline {
+            attachment: json.attachment.unwrap_or(Vec::new()),
+            color: color
+        })
+    }
+
+    pub fn interpolate_color(&self, elapsed: f32) -> [u8; 4] {
+        self.color.interpolate(elapsed).unwrap_or([255, 255, 255, 255])
+    }
+
+    pub fn interpolate_attachment(&self, elapsed: f32) -> Option<Option<&str>> {
+        if self.attachment.is_empty() || elapsed < self.attachment[0].time {
+            None
+        } else {
+            let pos = self.attachment.iter().position(|a| elapsed < a.time).unwrap_or(self.attachment.len());
+            Some(self.attachment[pos - 1].name.as_ref().map(|n| &**n))
+        }
+    }
+
+    pub fn get_attachment_names(&self) -> Vec<&str> {
+        self.attachment.iter()
+            .filter_map(|t| t.name.as_ref().map(|n| &**n)).collect()
+    }
+
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -3,37 +3,42 @@ extern crate spine;
 use std::io::BufReader;
 
 #[test]
-fn animations_list() {
+fn animations_names() {
     let src: &[u8] = include_bytes!("example.json");
-    let doc = spine::SpineDocument::new(BufReader::new(src)).unwrap();
+    let doc = spine::skeleton::Skeleton::from_reader(BufReader::new(src)).unwrap();
 
-    assert!(doc.get_animations_list().get(0).unwrap() == &"walk" ||
-        doc.get_animations_list().get(0).unwrap() == &"jump");
-    assert!(doc.get_animations_list().get(1).unwrap() == &"walk" ||
-        doc.get_animations_list().get(1).unwrap() == &"jump");
+    let names = doc.get_animations_names();
 
-    assert!(doc.has_animation("walk"));
-    assert!(doc.has_animation("jump"));
-    assert!(!doc.has_animation("crawl"));
+    assert!(names.get(0).unwrap() == &"walk" ||
+        names.get(0).unwrap() == &"jump");
+    assert!(names.get(1).unwrap() == &"walk" ||
+        names.get(1).unwrap() == &"jump");
+
+    assert!(names.contains(&"walk"));
+    assert!(names.contains(&"jump"));
+    assert!(!names.contains(&"crawl"));
 }
 
 #[test]
-fn skins_list() {
+fn skins_names() {
     let src: &[u8] = include_bytes!("example.json");
-    let doc = spine::SpineDocument::new(BufReader::new(src)).unwrap();
+    let doc = spine::skeleton::Skeleton::from_reader(BufReader::new(src)).unwrap();
+    let skins = doc.get_skins_names();
+    assert!(skins.get(0).unwrap() == &"default");
 
-    assert!(doc.get_skins_list().get(0).unwrap() == &"default");
+    assert!(skins.contains(&"default"));
+    assert!(doc.get_skin("default").is_ok());
 
-    assert!(doc.has_skin("default"));
-    assert!(!doc.has_skin("nonexisting"));
+    assert!(!skins.contains(&"nonexisting"));
+    assert!(doc.get_skin("nonexisting").is_err());
 }
 
 #[test]
-fn possible_sprites() {
+fn attachement_names() {
     let src: &[u8] = include_bytes!("example.json");
-    let doc = spine::SpineDocument::new(BufReader::new(src)).unwrap();
+    let doc = spine::skeleton::Skeleton::from_reader(BufReader::new(src)).unwrap();
 
-    let mut results = doc.get_possible_sprites();
+    let mut results = doc.get_attachments_names();
     results.sort();
 
     assert!(results == [


### PR DESCRIPTION
I've reached a nice step in rewriting the spine library. While it is still not ready for integration, I wanted to share this milestone:
1. `skeleton` module to handle all logic from the skeleton
2. `Skeleton` struct: precomputed version of the json data (working with indices etc...)
3. `timeline` module: contains all the logic about interpolation between timelines. It also computes all bezier points in advance when necessary (for now, 10 points only between 2 frames, as done in other runtimes)
4. `animation` module: provides an iterator created per skin/animation and iterates over an `SRT` (renaming of `BoneData`) and attachment name (color is coming soon)
   - All the transformations are done on `SRT` instead of using Matrices (from one of my previous PR, I found that Matrix are expensive and the other runtimes don't use them)
   - I find iterators more rusty. If you want to loop animations, you can simply use the [`Cycle`](http://doc.rust-lang.org/std/iter/trait.Iterator.html#method.cycle) iterator for instance
5. So far I did not need crates like cgmath or color, even if I had to use rustc-serialize for hexadecimal color parsing ...

The current milestone is that **it all compiles**. 

I intentionally kept old logic as they just share the same json deserialization and it is simpler to compare

I haven't cross checked figures yet, first benches show a x5 improvement.
That's it. I suppose I'll spend the next days trying to build a tool to _see_ the animation and figure how wrong I am (I've read your glium tutorial and it could be enough)
